### PR TITLE
add the download.html pages into the xcat.org repository

### DIFF
--- a/download.html
+++ b/download.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Download xCAT</title>
+<title>Download xCAT [2.11]</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <link rel="stylesheet" href="css/download.css">
 <link rel="stylesheet" href="css/default.css">
@@ -25,14 +25,14 @@
 
     There are a number of options provided for installing xCAT.  
     <ol>
-        <li> Download the tar.gz packages provided on this download page</li>
-        <li> Configure one of the hosted online repositories from your target machine</li>
-        <li> Clone the xcat-core project and compile from source (will still require xcat-dep)</li>
+        <li> Download the tar.bz2 packages provided on this download page</li>
+        <li> Configure the public hosted online repositories from your target machine</li>
+        <li> Clone the xcat-core project and compile from source (still requires xcat-dep)</li>
     </ol>
 
     Regardless of the option that is chosen to install xCAT, <b>BOTH </b> <u>xcat-core and xcat-dep</u> are needed before starting the install. <br><br>
 
-    <b><a href="#xcat-core">xCAT Core Packages(xcat-core)</a></b> is the main package containing xCAT software.  The following builds are available:
+    <b><a href="#xcat-core">xCAT Core Packages (xcat-core)</a></b> is the main package containing the xCAT software.  The following builds are available:
     <ul>
         <li> <a href="#release_builds">Release Builds (Stable)</a> - latest generally available (GA) build for xCAT </li>
         <li> <a href="#snapshot_builds">Snapshot Builds</a> - snapshot build of the latest GA version of xCAT which may contain fixes but has not GAed yet </li>
@@ -56,15 +56,15 @@
                 
                 <h4 id="linux-rpm-packages">Linux - RPM Packages</h4>
                 <ul>
-                    <li>Download <a href="https://github.com/xcat2/xcat-core/releases/download/2.10_release/xcat-core-2.10-linux.tar.bz2">xcat-core-2.10-linux.tar.bz2</a></li>
-                    <li>Online Repository: <a href="http://xcat.org/files/xcat/repos/yum/2.10/xcat-core/xCAT-core.repo">xCAT-core.repo</a></li>
+                    <li>Download <a href="http://xcat.org/files/xcat/xcat-core/2.11.x_Linux/xcat-core/xcat-core-2.11-linux.tar.bz2">xcat-core-2.11.tar.bz2</a></li>
+                    <li>Online Repository: <a href="http://xcat.org/files/xcat/repos/yum/2.11/xcat-core/xCAT-core.repo">xCAT-core.repo</a></li>
                 </ul>   
 
                 <h4 id="linux-deb-packages-ubuntu">Linux - Debian Packages (Ubuntu)</h4>
                 <ul>
-                    <li>Download: <a href="https://github.com/xcat2/xcat-core/releases/download/2.10_release/xcat-core-2.10-ubuntu.tar.bz2" rel="nofollow">xcat-core-2.10.tar.bz2</a></li>
+                    <li>Download: <a href="http://xcat.org/files/xcat/xcat-core/2.11.x_Ubuntu/xcat-core/xcat-core-2.11-ubuntu.tar.bz2" rel="nofollow">xcat-core-2.11.tar.bz2</a></li>
                     <li>    
-                        Online Repository: <p class="codetext"><b>deb <a href="http://xcat.org/files/xcat/repos/apt/2.10/xcat-core/">http://xcat.org/files/xcat/repos/apt/2.10/xcat-core</a> trusty main </b></p>
+                        Online Repository: <p class="codetext"><b>deb <a href="http://xcat.org/files/xcat/repos/apt/2.11/xcat-core/">http://xcat.org/files/xcat/repos/apt/2.11/xcat-core</a> trusty main </b></p>
                     </li>
                 </ul>   
                 <hr>
@@ -74,15 +74,15 @@
                         
                 <h4 id="linux-rpm-packages">Linux - RPM Packages</h4>
                 <ul>
-                    <li>Download <a href="http://xcat.org/files/xcat/xcat-core/2.10.x_Linux/core-snap/core-rpms-snap.tar.bz2">core-rpms-snap.tar.bz</a></li>
-                    <li>Online Repository: <a href="http://xcat.org/files/xcat/repos/yum/2.10/core-snap/xCAT-core.repo">xCAT-core.repo</a></li>
+                    <li>Download <a href="http://xcat.org/files/xcat/xcat-core/2.11.x_Linux/core-snap/core-rpms-snap.tar.bz2">core-rpms-snap.tar.bz2</a></li>
+                    <li>Online Repository: <a href="http://xcat.org/files/xcat/repos/yum/2.11/core-snap/xCAT-core.repo">xCAT-core.repo</a></li>
                 </ul>   
 
                 <h4 id="linux-deb-packages-ubuntu">Linux - Debian Packages (Ubuntu)</h4>
                 <ul>
-                    <li>Download: <a href="http://xcat.org/files/xcat/xcat-core/2.10.x_Ubuntu/core-snap/core-debs-snap.tar.bz2" rel="nofollow">core-debs-snap.tar.bz2</a></li>
+                    <li>Download: <a href="http://xcat.org/files/xcat/xcat-core/2.11.x_Ubuntu/core-snap/core-debs-snap.tar.bz2" rel="nofollow">core-debs-snap.tar.bz2</a></li>
                     <li>    
-                        Online Repository: <p class="codetext"><b>deb <a href="http://xcat.org/files/xcat/repos/apt/2.10/core-snap">http://xcat.org/files/xcat/repos/apt/2.10/core-snap</a> trusty main </b></p>
+                        Online Repository: <p class="codetext"><b>deb <a href="http://xcat.org/files/xcat/repos/apt/2.11/core-snap">http://xcat.org/files/xcat/repos/apt/2.11/core-snap</a> trusty main </b></p>
                     </li>
                 </ul>   
                 <hr>

--- a/download.html
+++ b/download.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Download xCAT [2.11]</title>
+<title>Download xCAT [2.11.1]</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <link rel="stylesheet" href="css/download.css">
 <link rel="stylesheet" href="css/default.css">
@@ -48,23 +48,23 @@
     <div id="download_section">
         <a name="xcat-core"><h2> xCAT Core Packages (xcat-core) </h2></a>
             <div id="download_files">
-                <p><i><b>Looking for older releases of xCAT? </b>Go to the <a href="http://www.xcat.org/files" target="_blank">File Manager</a> and navigate to the desired directory.</i>
+                <p><i><b>Looking for older releases of xCAT? </b>Go to the <a href="https://www.xcat.org/files" target="_blank">File Manager</a> and navigate to the desired directory.</i>
                 <hr>
 
-                <a name="release_builds"> <h3>Release Builds (Stable)</h3> </a>
+                <a name="release_builds"> <h3>Release Builds (Stable) - xCAT 2.11.1</h3> </a>
                 <p> This is the latest official released version of xCAT that has been fully tested. </p>
                 
                 <h4 id="linux-rpm-packages">Linux - RPM Packages</h4>
                 <ul>
-                    <li>Download <a href="http://xcat.org/files/xcat/xcat-core/2.11.x_Linux/xcat-core/xcat-core-2.11-linux.tar.bz2">xcat-core-2.11.tar.bz2</a></li>
-                    <li>Online Repository: <a href="http://xcat.org/files/xcat/repos/yum/2.11/xcat-core/xCAT-core.repo">xCAT-core.repo</a></li>
+                    <li>Download <a href="https://xcat.org/files/xcat/xcat-core/2.11.x_Linux/xcat-core/xcat-core-2.11.1-linux.tar.bz2">xcat-core-2.11.1.tar.bz2</a></li>
+                    <li>Online Repository: <a href="https://xcat.org/files/xcat/repos/yum/2.11/xcat-core/xCAT-core.repo">xCAT-core.repo</a></li>
                 </ul>   
 
                 <h4 id="linux-deb-packages-ubuntu">Linux - Debian Packages (Ubuntu)</h4>
                 <ul>
-                    <li>Download: <a href="http://xcat.org/files/xcat/xcat-core/2.11.x_Ubuntu/xcat-core/xcat-core-2.11-ubuntu.tar.bz2" rel="nofollow">xcat-core-2.11.tar.bz2</a></li>
+                    <li>Download: <a href="https://xcat.org/files/xcat/xcat-core/2.11.x_Ubuntu/xcat-core/xcat-core-2.11.1-ubuntu.tar.bz2" rel="nofollow">xcat-core-2.11.1.tar.bz2</a></li>
                     <li>    
-                        Online Repository: <p class="codetext"><b>deb <a href="http://xcat.org/files/xcat/repos/apt/2.11/xcat-core/">http://xcat.org/files/xcat/repos/apt/2.11/xcat-core</a> trusty main </b></p>
+                        Online Repository: <p class="codetext"><b>deb <a href="https://xcat.org/files/xcat/repos/apt/2.11/xcat-core/">http://xcat.org/files/xcat/repos/apt/2.11/xcat-core</a> trusty main </b></p>
                     </li>
                 </ul>   
                 <hr>
@@ -74,15 +74,15 @@
                         
                 <h4 id="linux-rpm-packages">Linux - RPM Packages</h4>
                 <ul>
-                    <li>Download <a href="http://xcat.org/files/xcat/xcat-core/2.11.x_Linux/core-snap/core-rpms-snap.tar.bz2">core-rpms-snap.tar.bz2</a></li>
-                    <li>Online Repository: <a href="http://xcat.org/files/xcat/repos/yum/2.11/core-snap/xCAT-core.repo">xCAT-core.repo</a></li>
+                    <li>Download <a href="https://xcat.org/files/xcat/xcat-core/2.11.x_Linux/core-snap/core-rpms-snap.tar.bz2">core-rpms-snap.tar.bz2</a></li>
+                    <li>Online Repository: <a href="https://xcat.org/files/xcat/repos/yum/2.11/core-snap/xCAT-core.repo">xCAT-core.repo</a></li>
                 </ul>   
 
                 <h4 id="linux-deb-packages-ubuntu">Linux - Debian Packages (Ubuntu)</h4>
                 <ul>
-                    <li>Download: <a href="http://xcat.org/files/xcat/xcat-core/2.11.x_Ubuntu/core-snap/core-debs-snap.tar.bz2" rel="nofollow">core-debs-snap.tar.bz2</a></li>
+                    <li>Download: <a href="https://xcat.org/files/xcat/xcat-core/2.11.x_Ubuntu/core-snap/core-debs-snap.tar.bz2" rel="nofollow">core-debs-snap.tar.bz2</a></li>
                     <li>    
-                        Online Repository: <p class="codetext"><b>deb <a href="http://xcat.org/files/xcat/repos/apt/2.11/core-snap">http://xcat.org/files/xcat/repos/apt/2.11/core-snap</a> trusty main </b></p>
+                        Online Repository: <p class="codetext"><b>deb <a href="https://xcat.org/files/xcat/repos/apt/2.11/core-snap">https://xcat.org/files/xcat/repos/apt/2.11/core-snap</a> trusty main </b></p>
                     </li>
                 </ul>   
                 <hr>
@@ -92,15 +92,15 @@
                         
                 <h4 id="linux-rpm-packages">Linux - RPM Packages</h4>
                 <ul>
-                    <li>Download <a href="http://xcat.org/files/xcat/xcat-core/devel/Linux/core-snap/core-rpms-snap.tar.bz2">core-rpms-snap.tar.bz2</a></li>
-                    <li>Online Repository: <a href="http://xcat.org/files/xcat/repos/yum/devel/core-snap/xCAT-core.repo">xCAT-core.repo</a></li>
+                    <li>Download <a href="https://xcat.org/files/xcat/xcat-core/devel/Linux/core-snap/core-rpms-snap.tar.bz2">core-rpms-snap.tar.bz2</a></li>
+                    <li>Online Repository: <a href="https://xcat.org/files/xcat/repos/yum/devel/core-snap/xCAT-core.repo">xCAT-core.repo</a></li>
                 </ul>   
 
                 <h4 id="linux-deb-packages-ubuntu">Linux - Debian Packages (Ubuntu)</h4>
                 <ul>
-                    <li>Download: <a href="http://xcat.org/files/xcat/xcat-core/devel/Ubuntu/core-snap/core-debs-snap.tar.bz2" rel="nofollow">core-debs-snap.tar.bz2</a></li>
+                    <li>Download: <a href="https://xcat.org/files/xcat/xcat-core/devel/Ubuntu/core-snap/core-debs-snap.tar.bz2" rel="nofollow">core-debs-snap.tar.bz2</a></li>
                     <li>    
-                        Online Repository: <p class="codetext"><b>deb <a href="http://xcat.org/files/xcat/repos/apt/devel/core-snap/">http://xcat.org/files/xcat/repos/apt/devel/core-snap</a> trusty main </b></p>
+                        Online Repository: <p class="codetext"><b>deb <a href="https://xcat.org/files/xcat/repos/apt/devel/core-snap/">https://xcat.org/files/xcat/repos/apt/devel/core-snap</a> trusty main </b></p>
                     </li>
                 </ul>   
                 <hr>
@@ -114,13 +114,13 @@
         <div id="download_files">
             <h4> Linux - RPM </h4>
             <ul>
-                <li> Download: <a href="http://xcat.org/files/xcat/xcat-dep/2.x_Linux/?C=M;O=D">xcat-dep</a> From the xcat-dep, it's recommended to choose the latest snap date.</li>
-                <li> Online Repository: <a href="http://xcat.org/files/xcat/repos/yum/xcat-dep">xcat-dep online repo</a>.  From the online repo, select the <b>os/arch</b> of your management node and configure yum/zypper with the provided xCAT-dep.repo file in that directory.</li>
+                <li> Download: <a href="https://xcat.org/files/xcat/xcat-dep/2.x_Linux/?C=M;O=D">xcat-dep</a> From the xcat-dep, it's recommended to choose the latest snap date.</li>
+                <li> Online Repository: <a href="https://xcat.org/files/xcat/repos/yum/xcat-dep">xcat-dep online repo</a>.  From the online repo, select the <b>os/arch</b> of your management node and configure yum/zypper with the provided xCAT-dep.repo file in that directory.</li>
             </ul>
             <h4> Linux - Debian (Ubuntu) </h4>
             <ul> 
-                <li> Download: <a href="http://xcat.org/files/xcat/xcat-dep/2.x_Ubuntu/?C=M;O=D">xcat-dep</a> Choose the latest snap date </li>
-                <li> Online Repository: <p class="codetext"><b>deb <a href="http://xcat.org/files/xcat/repos/apt/xcat-dep/">http://xcat.org/files/xcat/repos/apt/xcat-dep</a> trusty main </b></p> </li>
+                <li> Download: <a href="https://xcat.org/files/xcat/xcat-dep/2.x_Ubuntu/?C=M;O=D">xcat-dep</a> Choose the latest snap date </li>
+                <li> Online Repository: <p class="codetext"><b>deb <a href="https://xcat.org/files/xcat/repos/apt/xcat-dep/">https://xcat.org/files/xcat/repos/apt/xcat-dep</a> trusty main </b></p> </li>
             </ul>
         </div>
     </div>

--- a/download.html
+++ b/download.html
@@ -1,0 +1,133 @@
+<html>
+<head>
+<title>Download xCAT</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<link rel="stylesheet" href="css/download.css">
+<link rel="stylesheet" href="css/default.css">
+</head>
+<body>
+<div id="navigator">
+<a href="/"><img id="logo" src="images/xcat-logo.png" alt="xCAT Logo" title="xCAT Logo"></a>
+<p>
+<a href="/files/">Download</a> |
+<a href="http://xcat-docs.readthedocs.org/">Documentation</a> |
+<a href="http://sourceforge.net/p/xcat/mailman/">Mailling List</a> |
+<a href="http://github.com/xcat2/xcat-core/issues">Issues</a> |
+<a href="http://github.com/xcat2/xcat-core">GitHub</a>
+</p>
+</div>
+</head>
+
+<div class="container">
+    <div id="download_main">
+
+    <h2>Download xCAT</h2>
+
+    There are a number of options provided for installing xCAT.  
+    <ol>
+        <li> Download the tar.gz packages provided on this download page</li>
+        <li> Configure one of the hosted online repositories from your target machine</li>
+        <li> Clone the xcat-core project and compile from source (will still require xcat-dep)</li>
+    </ol>
+
+    Regardless of the option that is chosen to install xCAT, <b>BOTH </b> <u>xcat-core and xcat-dep</u> are needed before starting the install. <br><br>
+
+    <b><a href="#xcat-core">xCAT Core Packages(xcat-core)</a></b> is the main package containing xCAT software.  The following builds are available:
+    <ul>
+        <li> <a href="#release_builds">Release Builds (Stable)</a> - latest generally available (GA) build for xCAT </li>
+        <li> <a href="#snapshot_builds">Snapshot Builds</a> - snapshot build of the latest GA version of xCAT which may contain fixes but has not GAed yet </li>
+        <li> <a href="#development_builds">Development Builds</a> - snapshot builds of the next version of xCAT </li>
+        <li> <a href="https://sourceforge.net/p/xcat/wiki/XCAT_Developer_Guide/#building-xcat-core-from-xcat-core-git-repository" target="_blank">Build the xcat-core tarball from source</a> - xCAT 2.10 and later supports building the xcat-core tarball from the cloned repository. </li>
+    </ul>
+
+    <b><a href="#xcat-dep">xCAT Dependency Packages (xcat-dep)</a></b> is a tar package that is provided as a convenience for the user and contains dependency packages required by xCAT that are not provided by the operating system. 
+
+    </div>
+    <br><br>
+
+    <div id="download_section">
+        <a name="xcat-core"><h2> xCAT Core Packages (xcat-core) </h2></a>
+            <div id="download_files">
+                <p><i><b>Looking for older releases of xCAT? </b>Go to the <a href="http://www.xcat.org/files" target="_blank">File Manager</a> and navigate to the desired directory.</i>
+                <hr>
+
+                <a name="release_builds"> <h3>Release Builds (Stable)</h3> </a>
+                <p> This is the latest official released version of xCAT that has been fully tested. </p>
+                
+                <h4 id="linux-rpm-packages">Linux - RPM Packages</h4>
+                <ul>
+                    <li>Download <a href="https://github.com/xcat2/xcat-core/releases/download/2.10_release/xcat-core-2.10-linux.tar.bz2">xcat-core-2.10-linux.tar.bz2</a></li>
+                    <li>Online Repository: <a href="http://xcat.org/files/xcat/repos/yum/2.10/xcat-core/xCAT-core.repo">xCAT-core.repo</a></li>
+                </ul>   
+
+                <h4 id="linux-deb-packages-ubuntu">Linux - Debian Packages (Ubuntu)</h4>
+                <ul>
+                    <li>Download: <a href="https://github.com/xcat2/xcat-core/releases/download/2.10_release/xcat-core-2.10-ubuntu.tar.bz2" rel="nofollow">xcat-core-2.10.tar.bz2</a></li>
+                    <li>    
+                        Online Repository: <p class="codetext"><b>deb <a href="http://xcat.org/files/xcat/repos/apt/2.10/xcat-core/">http://xcat.org/files/xcat/repos/apt/2.10/xcat-core</a> trusty main </b></p>
+                    </li>
+                </ul>   
+                <hr>
+
+                <a name="snapshot_builds"><h3>Snapshot Builds</h3></a>
+                <p> These are snapshot builds for the current release, which will be released in the next xCAT refresh of the currently released version </p>
+                        
+                <h4 id="linux-rpm-packages">Linux - RPM Packages</h4>
+                <ul>
+                    <li>Download <a href="http://xcat.org/files/xcat/xcat-core/2.10.x_Linux/core-snap/core-rpms-snap.tar.bz2">core-rpms-snap.tar.bz</a></li>
+                    <li>Online Repository: <a href="http://xcat.org/files/xcat/repos/yum/2.10/core-snap/xCAT-core.repo">xCAT-core.repo</a></li>
+                </ul>   
+
+                <h4 id="linux-deb-packages-ubuntu">Linux - Debian Packages (Ubuntu)</h4>
+                <ul>
+                    <li>Download: <a href="http://xcat.org/files/xcat/xcat-core/2.10.x_Ubuntu/core-snap/core-debs-snap.tar.bz2" rel="nofollow">core-debs-snap.tar.bz2</a></li>
+                    <li>    
+                        Online Repository: <p class="codetext"><b>deb <a href="http://xcat.org/files/xcat/repos/apt/2.10/core-snap">http://xcat.org/files/xcat/repos/apt/2.10/core-snap</a> trusty main </b></p>
+                    </li>
+                </ul>   
+                <hr>
+
+                <a name="development_builds"><h3>Development Builds</h3></a>
+                <p> This is the latest development build we are working on for the next xCAT release </p>
+                        
+                <h4 id="linux-rpm-packages">Linux - RPM Packages</h4>
+                <ul>
+                    <li>Download <a href="http://xcat.org/files/xcat/xcat-core/devel/Linux/core-snap/core-rpms-snap.tar.bz2">core-rpms-snap.tar.bz2</a></li>
+                    <li>Online Repository: <a href="http://xcat.org/files/xcat/repos/yum/devel/core-snap/xCAT-core.repo">xCAT-core.repo</a></li>
+                </ul>   
+
+                <h4 id="linux-deb-packages-ubuntu">Linux - Debian Packages (Ubuntu)</h4>
+                <ul>
+                    <li>Download: <a href="http://xcat.org/files/xcat/xcat-core/devel/Ubuntu/core-snap/core-debs-snap.tar.bz2" rel="nofollow">core-debs-snap.tar.bz2</a></li>
+                    <li>    
+                        Online Repository: <p class="codetext"><b>deb <a href="http://xcat.org/files/xcat/repos/apt/devel/core-snap/">http://xcat.org/files/xcat/repos/apt/devel/core-snap</a> trusty main </b></p>
+                    </li>
+                </ul>   
+                <hr>
+            </div>
+        </div>
+    <br><br>
+
+    <div id="download_section">
+        <a name="xcat-dep"><h2> xCAT Dependency Packages (xcat-dep) </h2></a>
+
+        <div id="download_files">
+            <h4> Linux - RPM </h4>
+            <ul>
+                <li> Download: <a href="http://xcat.org/files/xcat/xcat-dep/2.x_Linux/?C=M;O=D">xcat-dep</a> From the xcat-dep, it's recommended to choose the latest snap date.</li>
+                <li> Online Repository: <a href="http://xcat.org/files/xcat/repos/yum/xcat-dep">xcat-dep online repo</a>.  From the online repo, select the <b>os/arch</b> of your management node and configure yum/zypper with the provided xCAT-dep.repo file in that directory.</li>
+            </ul>
+            <h4> Linux - Debian (Ubuntu) </h4>
+            <ul> 
+                <li> Download: <a href="http://xcat.org/files/xcat/xcat-dep/2.x_Ubuntu/?C=M;O=D">xcat-dep</a> Choose the latest snap date </li>
+                <li> Online Repository: <p class="codetext"><b>deb <a href="http://xcat.org/files/xcat/repos/apt/xcat-dep/">http://xcat.org/files/xcat/repos/apt/xcat-dep</a> trusty main </b></p> </li>
+            </ul>
+        </div>
+    </div>
+
+<br><br>
+
+</div>
+</div>
+</html>
+


### PR DESCRIPTION
Checked in the pages from the 2.10, 2.11, and 2.11.1 release to the repository 