### PR TITLE
Move the go-xcat section into a new section on the downlod page

### DIFF
--- a/download.html
+++ b/download.html
@@ -27,8 +27,8 @@
     <br>On the target xCAT Management Node, run the following commands to install the latest version of xCAT:
     <pre class="codetext">
        wget http://xcat.org/files/go-xcat -O - &gt;/tmp/go-xcat
-       chmod +x go-xcat
-       ./go-xcat
+       chmod +x /tmp/go-xcat
+       /tmp/go-xcat
     </pre>
 
     <h2>Download xCAT</h2>

--- a/download.html
+++ b/download.html
@@ -22,14 +22,14 @@
 
     <h2>Installing with go-xcat <sup class="new">New!</sup> </h2>
 
-    To easily install xCAT and handle the dependency package, a new script <a href=http://xcat.org/files/go-xcat>go-xcat</a> is provided.
-    <br><br>Download and then run the following: 
+    To easily install xCAT and handle the dependency package, a new script <b>go-xcat</b> is provided.
+    <br>
+    <br>On the target xCAT Management Node, run the following commands to install the latest version of xCAT:
     <pre class="codetext">
+       wget http://xcat.org/files/go-xcat -O - &gt;/tmp/go-xcat
        chmod +x go-xcat
        ./go-xcat
     </pre>
-
-    <p>This will install the latest version of xcat using the xcat.org repository  (The target machine must have connectivity to <a href=http://xcat.org>http://xcat.org</a>)</p>
 
     <h2>Download xCAT</h2>
 

--- a/download.html
+++ b/download.html
@@ -20,6 +20,17 @@
 <div class="container">
     <div class="download_main">
 
+    <h2>Installing with go-xcat <sup class="new">New!</sup> </h2>
+
+    To easily install xCAT and handle the dependency package, a new script <a href=http://xcat.org/files/go-xcat>go-xcat</a> is provided.
+    <br><br>Download and then run the following: 
+    <pre class="codetext">
+       chmod +x go-xcat
+       ./go-xcat
+    </pre>
+
+    <p>This will install the latest version of xcat using the xcat.org repository  (The target machine must have connectivity to <a href=http://xcat.org>http://xcat.org</a>)</p>
+
     <h2>Download xCAT</h2>
 
     <p>There are a number of options provided for installing xCAT.</p>
@@ -30,14 +41,6 @@
     </ol>
 
     <p>Regardless of the option that is chosen to install xCAT, <b>BOTH</b> <tt>xcat-core</tt> and <tt>xcat-dep</tt> are needed before starting the install.</p>
-
-    <p><sup class="new">New!</sup> For a simple xCAT installation solution, just type the following at your shell prompt</p>
-    <pre class="codetext">
-    wget http://xcat.org/files/go-xcat -O - &gt;/tmp/go-xcat
-    chmod +x /tmp/go-xcat
-    /tmp/go-xcat install</pre>
-
-    <p>This will install xCAT to use the default xcat.org repository.</p>
 
     <b><a href="#xcat-core">xCAT Core Packages (xcat-core)</a></b> is the main package containing the xCAT software.  The following builds are available:
     <ul>


### PR DESCRIPTION
The new section is called 'Install with go-xcat' and it makes it more clear about the new installation script provided. 

I removed the wget command because I think we can allow the user to download the file any way they want.  I don't see why they need those specific options.  