### PR TITLE
Suggest using https for 'go-xcat'

### DIFF
--- a/download.html
+++ b/download.html
@@ -26,7 +26,7 @@
     <br>
     <br>On the target xCAT Management Node, run the following commands to install the latest version of xCAT:
     <pre class="codetext">
-       wget http://xcat.org/files/go-xcat -O - &gt;/tmp/go-xcat
+       wget https://xcat.org/files/go-xcat -O - &gt;/tmp/go-xcat
        chmod +x /tmp/go-xcat
        /tmp/go-xcat
     </pre>


### PR DESCRIPTION
Particularly for something that will be
run as a script, using http directly seems
especially perilous.