### PR TITLE
Add the amd64 and ppc64el specific tags for the Ubuntu online repositories

### DIFF
--- a/download.html
+++ b/download.html
@@ -77,12 +77,22 @@
                 <ul>
                     <li>Download: <a href="https://xcat.org/files/xcat/xcat-core/2.12.x_Ubuntu/xcat-core/xcat-core-2.12.1-ubuntu.tar.bz2" rel="nofollow">xcat-core-2.12.1-ubuntu.tar.bz2</a></li>
                     <li>
-                        Ubuntu Online Repository: 
-                        <p class="codetext">deb <a href="https://xcat.org/files/xcat/repos/apt/2.12/xcat-core/">http://xcat.org/files/xcat/repos/apt/2.12/xcat-core</a> trusty main</p>
+                        Ubuntu Online Repository: <br>
+                            &nbsp; <i>For x86_64 servers: </i>
+                            <p class="codetext">
+                            &nbsp; deb [arch=amd64] <a href="https://xcat.org/files/xcat/repos/apt/2.12/xcat-core/">http://xcat.org/files/xcat/repos/apt/2.12/xcat-core</a> trusty main</p>
+                            &nbsp; <i>For ppc64el servers: </i>
+                            <p class="codetext">
+                            &nbsp; deb [arch=ppc64el] <a href="https://xcat.org/files/xcat/repos/apt/2.12/xcat-core/">http://xcat.org/files/xcat/repos/apt/2.12/xcat-core</a> trusty main</p>
                     </li>
                     <li>
-                        Latest Repository (This repo points to the latest stable build of xCAT):
-                        <p class="codetext">deb <a href="https://xcat.org/files/xcat/repos/apt/latest/xcat-core/">http://xcat.org/files/xcat/repos/apt/latest/xcat-core</a> trusty main</p>
+                        Latest Repository (This repo points to the latest stable build of xCAT):<br>
+                        &nbsp; <i>For x86_64 servers: </i>
+                        <p class="codetext">
+                        &nbsp; deb [arch=amd64] <a href="https://xcat.org/files/xcat/repos/apt/latest/xcat-core/">http://xcat.org/files/xcat/repos/apt/latest/xcat-core</a> trusty main</p>
+                        &nbsp; <i>For ppc64el servers: </i>
+                        <p class="codetext">
+                        &nbsp; deb [arch=ppc64el] <a href="https://xcat.org/files/xcat/repos/apt/latest/xcat-core/">http://xcat.org/files/xcat/repos/apt/latest/xcat-core</a> trusty main</p>
                     </li>
                 </ul>   
                 <hr>
@@ -100,7 +110,13 @@
                 <ul>
                     <li>Download: <a href="https://xcat.org/files/xcat/xcat-core/2.12.x_Ubuntu/core-snap/core-debs-snap.tar.bz2" rel="nofollow">core-debs-snap.tar.bz2</a></li>
                     <li>    
-                        Ubuntu Online Repository: <p class="codetext">deb <a href="https://xcat.org/files/xcat/repos/apt/2.12/core-snap">https://xcat.org/files/xcat/repos/apt/2.12/core-snap</a> trusty main</p>
+                        Ubuntu Online Repository:<br> 
+                        &nbsp; <i>For x86_64 servers: </i>
+                        <p class="codetext">
+                        &nbsp; deb [arch=amd64] <a href="https://xcat.org/files/xcat/repos/apt/2.12/core-snap">https://xcat.org/files/xcat/repos/apt/2.12/core-snap</a> trusty main</p>
+                        &nbsp; <i>For ppc64el servers: </i>
+                        <p class="codetext">
+                        &nbsp; deb [arch=ppc64el] <a href="https://xcat.org/files/xcat/repos/apt/2.12/core-snap">https://xcat.org/files/xcat/repos/apt/2.12/core-snap</a> trusty main</p>
                     </li>
                 </ul>   
                 <hr>
@@ -118,7 +134,13 @@
                 <ul>
                     <li>Download: <a href="https://xcat.org/files/xcat/xcat-core/devel/Ubuntu/core-snap/core-debs-snap.tar.bz2" rel="nofollow">core-debs-snap.tar.bz2</a></li>
                     <li>    
-                        Ubuntu Online Repository: <p class="codetext">deb <a href="https://xcat.org/files/xcat/repos/apt/devel/core-snap/">https://xcat.org/files/xcat/repos/apt/devel/core-snap</a> trusty main</p>
+                        Ubuntu Online Repository: <br>
+                        &nbsp; <i>For x86_64 servers: </i>
+                        <p class="codetext">
+                        &nbsp; deb [arch=amd64] <a href="https://xcat.org/files/xcat/repos/apt/devel/core-snap/">https://xcat.org/files/xcat/repos/apt/devel/core-snap</a> trusty main</p>
+                        &nbsp; <i>For ppc64el servers: </i>
+                        <p class="codetext">
+                        &nbsp; deb [arch=ppc64el] <a href="https://xcat.org/files/xcat/repos/apt/devel/core-snap/">https://xcat.org/files/xcat/repos/apt/devel/core-snap</a> trusty main</p>
                     </li>
                 </ul>   
                 <hr>
@@ -138,9 +160,18 @@
             <h4> Linux - Debian (Ubuntu) </h4>
             <ul> 
                 <li> Download: <a href="https://xcat.org/files/xcat/xcat-dep/2.x_Ubuntu/?C=M;O=D">xcat-dep</a> Choose the latest snap date </li>
-                <li> Ubuntu Online Repository: <p class="codetext">deb <a href="https://xcat.org/files/xcat/repos/apt/xcat-dep/">https://xcat.org/files/xcat/repos/apt/xcat-dep</a> trusty main</p></li>
+                <li> 
+                    Ubuntu Online Repository: <br>
+                    &nbsp; <i>For x86_64 servers: </i>
+                    <p class="codetext">
+                    &nbsp; deb [arch=amd64] <a href="https://xcat.org/files/xcat/repos/apt/xcat-dep/">https://xcat.org/files/xcat/repos/apt/xcat-dep</a> trusty main</p>
+                    &nbsp; <i>For ppc64el servers: </i>
+                    <p class="codetext">
+                    &nbsp; deb [arch=ppc64el] <a href="https://xcat.org/files/xcat/repos/apt/xcat-dep/">https://xcat.org/files/xcat/repos/apt/xcat-dep</a> trusty main</p>
+                </li>
             </ul>
         </div>
     </div>
+    <br><br><br>
 </div>
 </html>


### PR DESCRIPTION
Similar to the changes made in PR: https://github.com/xcat2/xcat-core/pull/1705, updating the 
download.html page for xcat.org

Address https://github.com/xcat2/xcat-core/issues/1416