### PR TITLE
Create changes for xcat.org to prepare for 2.12.2 release

### DIFF
--- a/download.html
+++ b/download.html
@@ -11,10 +11,10 @@
 <a href="/"><img id="logo" src="images/xcat-logo.png" alt="xCAT Logo" title="xCAT Logo"></a>
 <p>
 <a href="/files/">Download</a> |
-<a href="http://xcat-docs.readthedocs.org/">Documentation</a> |
-<a href="http://sourceforge.net/p/xcat/mailman/">Mailling List</a> |
-<a href="http://github.com/xcat2/xcat-core/issues">Issues</a> |
-<a href="http://github.com/xcat2/xcat-core">GitHub</a>
+<a href="http://xcat-docs.readthedocs.io">Documentation</a> |
+<a href="https://sourceforge.net/p/xcat/mailman/">Mailling List</a> |
+<a href="https://github.com/xcat2/xcat-core/issues">Issues</a> |
+<a href="https://github.com/xcat2/xcat-core">GitHub</a>
 </p>
 </div>
 <div class="container">
@@ -80,19 +80,19 @@
                         Ubuntu Online Repository: <br>
                             &nbsp; <i>For x86_64 servers: </i>
                             <p class="codetext">
-                            &nbsp; deb [arch=amd64] <a href="https://xcat.org/files/xcat/repos/apt/2.12/xcat-core/">http://xcat.org/files/xcat/repos/apt/2.12/xcat-core</a> trusty main</p>
+                            &nbsp; deb [arch=amd64] <a href="https://xcat.org/files/xcat/repos/apt/2.12/xcat-core/">https://xcat.org/files/xcat/repos/apt/2.12/xcat-core</a> trusty main</p>
                             &nbsp; <i>For ppc64el servers: </i>
                             <p class="codetext">
-                            &nbsp; deb [arch=ppc64el] <a href="https://xcat.org/files/xcat/repos/apt/2.12/xcat-core/">http://xcat.org/files/xcat/repos/apt/2.12/xcat-core</a> trusty main</p>
+                            &nbsp; deb [arch=ppc64el] <a href="https://xcat.org/files/xcat/repos/apt/2.12/xcat-core/">https://xcat.org/files/xcat/repos/apt/2.12/xcat-core</a> trusty main</p>
                     </li>
                     <li>
                         Latest Repository (This repo points to the latest stable build of xCAT):<br>
                         &nbsp; <i>For x86_64 servers: </i>
                         <p class="codetext">
-                        &nbsp; deb [arch=amd64] <a href="https://xcat.org/files/xcat/repos/apt/latest/xcat-core/">http://xcat.org/files/xcat/repos/apt/latest/xcat-core</a> trusty main</p>
+                        &nbsp; deb [arch=amd64] <a href="https://xcat.org/files/xcat/repos/apt/latest/xcat-core/">https://xcat.org/files/xcat/repos/apt/latest/xcat-core</a> trusty main</p>
                         &nbsp; <i>For ppc64el servers: </i>
                         <p class="codetext">
-                        &nbsp; deb [arch=ppc64el] <a href="https://xcat.org/files/xcat/repos/apt/latest/xcat-core/">http://xcat.org/files/xcat/repos/apt/latest/xcat-core</a> trusty main</p>
+                        &nbsp; deb [arch=ppc64el] <a href="https://xcat.org/files/xcat/repos/apt/latest/xcat-core/">https://xcat.org/files/xcat/repos/apt/latest/xcat-core</a> trusty main</p>
                     </li>
                 </ul>   
                 <hr>

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
     <div id="sidebar">
     <h2>News</h2>
     <ul>
+        <li>Aug 19, 2016: <a href="https://github.com/xcat2/xcat-core/wiki/XCAT_2.12.2_Release_Notes/">xCAT 2.12.2</a> released</li>
         <li>Jul  8, 2016: <a href="https://github.com/xcat2/xcat-core/wiki/XCAT_2.12.1_Release_Notes/">xCAT 2.12.1</a> released</li>
         <li>May 20, 2016: <a href="https://github.com/xcat2/xcat-core/wiki/XCAT_2.12_Release_Notes/">xCAT 2.12</a> released</li>
         <li>Apr 22, 2016: <a href="https://github.com/xcat2/xcat-core/wiki/XCAT_2.11.1_Release_Notes/">xCAT 2.11.1</a> released</li>


### PR DESCRIPTION
* update the sidebar to include the 2.12.2 release information
* add support for the promote script to create the latest link on a snap build
* fix some URLs on the download page