### PR TITLE
Change the wget URL to use go-xcat in xcat-core repo instead of xcat-extensions

### DIFF
--- a/download.html
+++ b/download.html
@@ -26,7 +26,7 @@
     <br>
     <br>On the target xCAT Management Node, run the following commands to install the latest version of xCAT:
     <pre class="codetext">
-       wget https://raw.githubusercontent.com/xcat2/xcat-extensions/master/helper/go-xcat -O - &gt;/tmp/go-xcat
+       wget https://raw.githubusercontent.com/xcat2/xcat-core/master/xCAT-server/share/xcat/tools/go-xcat -O - &gt;/tmp/go-xcat
        chmod +x /tmp/go-xcat
        /tmp/go-xcat
     </pre>


### PR DESCRIPTION
Based on comments from #41, changing the URL to point to xcat-core project. 

Testing on SLES
```
c910f04x42vm100:~ # wget https://raw.githubusercontent.com/xcat2/xcat-core/master/xCAT-server/share/xcat/tools/go-xcat -O - >/tmp/go-xcat
--2016-12-08 10:54:31--  https://raw.githubusercontent.com/xcat2/xcat-core/master/xCAT-server/share/xcat/tools/go-xcat
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 151.101.20.133
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|151.101.20.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 39750 (39K) [text/plain]
Saving to: ‘STDOUT’

100%[=========================================================================================================================================================================>] 39,750      --.-K/s   in 0.007s

2016-12-08 10:54:31 (5.58 MB/s) - written to stdout [39750/39750]
```