### PR TITLE
Fix bug for download.html : xCAT-core.repo has been changed to xcat-core.repo

### DIFF
--- a/download.html
+++ b/download.html
@@ -67,9 +67,9 @@
                 <h4>Linux - RPM Packages</h4>
                 <ul>
                     <li>Download <a href="https://xcat.org/files/xcat/xcat-core/2.14.x_Linux/xcat-core/xcat-core-2.14.0-linux.tar.bz2">xcat-core-2.14.0-linux.tar.bz2</a></li>
-                    <li>Linux Online Repository: <a href="https://xcat.org/files/xcat/repos/yum/2.14/xcat-core/xCAT-core.repo">xCAT-core.repo</a></li>
+                    <li>Linux Online Repository: <a href="https://xcat.org/files/xcat/repos/yum/2.14/xcat-core/xcat-core.repo">xcat-core.repo</a></li>
                     <li>Latest Repository (This repo points to the latest stable build of xCAT):
-                        <a href="https://xcat.org/files/xcat/repos/yum/latest/xcat-core/xCAT-core.repo">xCAT-core.repo</a>
+                        <a href="https://xcat.org/files/xcat/repos/yum/latest/xcat-core/xcat-core.repo">xcat-core.repo</a>
                     </li>
                 </ul>   
 
@@ -103,7 +103,7 @@
                 <h4>Linux - RPM Packages</h4>
                 <ul>
                     <li>Download <a href="https://xcat.org/files/xcat/xcat-core/2.14.x_Linux/core-snap/core-rpms-snap.tar.bz2">core-rpms-snap.tar.bz2</a></li>
-                    <li>Linux Online Repository: <a href="https://xcat.org/files/xcat/repos/yum/2.14/core-snap/xCAT-core.repo">xCAT-core.repo</a></li>
+                    <li>Linux Online Repository: <a href="https://xcat.org/files/xcat/repos/yum/2.14/core-snap/xcat-core.repo">xcat-core.repo</a></li>
                 </ul>   
 
                 <h4>Linux - Debian Packages (Ubuntu)</h4>
@@ -127,7 +127,7 @@
                 <h4 class="linux-rpm-packages">Linux - RPM Packages</h4>
                 <ul>
                     <li>Download <a href="https://xcat.org/files/xcat/xcat-core/devel/Linux/core-snap/core-rpms-snap.tar.bz2">core-rpms-snap.tar.bz2</a></li>
-                    <li>Linux Online Repository: <a href="https://xcat.org/files/xcat/repos/yum/devel/core-snap/xCAT-core.repo">xCAT-core.repo</a></li>
+                    <li>Linux Online Repository: <a href="https://xcat.org/files/xcat/repos/yum/devel/core-snap/xcat-core.repo">xcat-core.repo</a></li>
                 </ul>   
 
                 <h4>Linux - Debian Packages (Ubuntu)</h4>


### PR DESCRIPTION
Due to the repo file name of ``xCAT-core.repo`` has been changed to ``xcat-core.repo``, so update this information in ``download.html`` file.